### PR TITLE
ci: Automate version bump to v0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "al-rusty-crystals-dilithium"
-version = "1.0.0"
+version = "0.0.1"
 dependencies = [
  "criterion",
  "rand 0.7.3",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "al-rusty-crystals-hdwallet"
-version = "0.1.1"
+version = "0.0.1"
 dependencies = [
  "al-rusty-crystals-dilithium",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 members = ["dilithium", "hdwallet"]
 
 [workspace.dependencies]
-al-rusty-crystals-dilithium = { path = "./dilithium", version = "1.0.0" }
-al-rusty-crystals-hdwallet = { path = "./hdwallet", version = "0.1.1" }
+al-rusty-crystals-dilithium = { path = "./dilithium", version = "0.0.1" }
+al-rusty-crystals-hdwallet = { path = "./hdwallet", version = "0.0.1" }
 thiserror = "2.0.4"
 
 [package]

--- a/dilithium/Cargo.toml
+++ b/dilithium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "al-rusty-crystals-dilithium"
-version = "1.0.0"
+version = "0.0.1"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of CRYSTALS-Dilithium digital signature scheme"

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "al-rusty-crystals-hdwallet"
-version = "0.1.1"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Automated version bump for release v0.0.1.

https://github.com/aletheia-labs/qp-rusty-crystals-rm/actions/runs/17485822327

Triggered by workflow run: patch

Type: 