### PR TITLE
ci: Automate dilithium version bump to dilithium-v0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "al-rusty-crystals-dilithium"
-version = "1.0.0"
+version = "0.0.1"
 dependencies = [
  "criterion",
  "rand 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["dilithium", "hdwallet"]
 
 [workspace.dependencies]
-al-rusty-crystals-dilithium = { path = "./dilithium", version = "1.0.0" }
+al-rusty-crystals-dilithium = { path = "./dilithium", version = "0.0.1" }
 al-rusty-crystals-hdwallet = { path = "./hdwallet", version = "0.1.1" }
 thiserror = "2.0.4"
 

--- a/dilithium/Cargo.toml
+++ b/dilithium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "al-rusty-crystals-dilithium"
-version = "1.0.0"
+version = "0.0.1"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of CRYSTALS-Dilithium digital signature scheme"


### PR DESCRIPTION
Automated dilithium version bump for release dilithium-v0.0.1.

https://github.com/aletheia-labs/qp-rusty-crystals-rm/actions/runs/17486375211

Triggered by workflow run: patch

Type: 