### PR TITLE
ci: Automate hdwallet version bump to hdwallet-v0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "al-rusty-crystals-hdwallet"
-version = "0.1.1"
+version = "0.0.1"
 dependencies = [
  "al-rusty-crystals-dilithium",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["dilithium", "hdwallet"]
 
 [workspace.dependencies]
 al-rusty-crystals-dilithium = { path = "./dilithium", version = "0.0.2" }
-al-rusty-crystals-hdwallet = { path = "./hdwallet", version = "0.1.1" }
+al-rusty-crystals-hdwallet = { path = "./hdwallet", version = "0.0.1" }
 thiserror = "2.0.4"
 
 [package]

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "al-rusty-crystals-hdwallet"
-version = "0.1.1"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Automated hdwallet version bump for release hdwallet-v0.0.1.

Also updates dilithium dependency to version 0.0.2.

Triggered by workflow run: https://github.com/aletheia-labs/qp-rusty-crystals-rm/actions/runs/17487584019

Type: patch