### PR TITLE
ci: Automate hdwallet version bump to hdwallet-v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "al-rusty-crystals-hdwallet"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-rusty-crystals-dilithium",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["dilithium", "hdwallet"]
 
 [workspace.dependencies]
 al-rusty-crystals-dilithium = { path = "./dilithium", version = "0.0.3" }
-al-rusty-crystals-hdwallet = { path = "./hdwallet", version = "0.0.2" }
+al-rusty-crystals-hdwallet = { path = "./hdwallet", version = "0.0.3" }
 thiserror = "2.0.4"
 
 [package]

--- a/hdwallet/Cargo.toml
+++ b/hdwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "al-rusty-crystals-hdwallet"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "GPL-3.0"
 description = "Pure Quantus RUST implementation of HD wallet functionality with post-quantum cryptography"


### PR DESCRIPTION
Automated hdwallet version bump for release hdwallet-v0.0.3.

Triggered by workflow run: https://github.com/aletheia-labs/qp-rusty-crystals-rm/actions/runs/17491582730

Type: patch